### PR TITLE
Move build status markdown to new line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# saml-ios-swift [![Build Status](https://travis-ci.org/feedhenry-templates/saml-ios-swift.png)](https://travis-ci.org/feedhenry-templates/saml-ios-swift)
+# saml-ios-swift
+[![Build Status](https://travis-ci.org/feedhenry-templates/saml-ios-swift.png)](https://travis-ci.org/feedhenry-templates/saml-ios-swift)
 
 > ObjC version is available [here](https://github.com/feedhenry-templates/saml-ios-app/).
 


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/FH-3422

Motivation: Studio cannot convert the markdown if it's on the same line as the header